### PR TITLE
Fix SVG config for Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ const customJestConfig = {
   testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
-    '^@components/(.*)$': '<rootDir>/components/$1',
-    '^@features/(.*)$': '<rootDir>/features/$1',
-    '^@views/(.*)$': '<rootDir>/views/$1',
-    '^@svg/(.*)$': '<rootDir>/svg/$1',
+    '^@components/(.*)$': '<rootDir>/src/components/$1',
+    '^@features/(.*)$': '<rootDir>/src/features/$1',
+    '^@views/(.*)$': '<rootDir>/src/views/$1',
+    '^.+\\.(svg)$': '<rootDir>/src/__mocks__/componentMock.js',
   },
 };
 

--- a/src/__mocks__/componentMock.js
+++ b/src/__mocks__/componentMock.js
@@ -1,0 +1,5 @@
+function MockedComponent(props) {
+  return <div {...props} />;
+}
+
+export default MockedComponent;


### PR DESCRIPTION
Override Next.js's default config for SVG files with a component mock. Default SVG components are replaced with a `<div />` that can receive any props/HTML attributes.